### PR TITLE
More benchmarks and better naive code

### DIFF
--- a/benchmarking/benchmark.exs
+++ b/benchmarking/benchmark.exs
@@ -1,48 +1,32 @@
-twohundred_kilobyte_example = File.read!("benchmarking/hll_server_list-single_error.json")
-
-defmodule UniRecover.Benchmark.Naive do
-
-  @doc """
-  Idiomatic solution utilizing the standard library.
-  """
-  def sub(s) when is_binary(s) do
-    s
-    |> String.graphemes()
-    |> Enum.filter(&String.valid?/1)
-    |> IO.iodata_to_binary()
-  end
-end
-
 defmodule UniRecover.Benchmark.Simple do
-  @dialyzer(:no_improper_lists)
+  @dialyzer :no_improper_lists
 
   @doc """
   Replaces illegal sequences by building a new string, sans the bad sequences.
-  This solution works better but still uses an outsized amount of memory and
-  compute relative to its input.
+  Naive but does not compute the minimal sequence and is slower.
   """
   def sub(s) when is_binary(s) do
-    do_filter(s)
+    do_filter(s, <<>>)
   end
-
-  defp do_filter(bin, acc \\ [])
 
   defp do_filter(<<grapheme::utf8, rest::binary>>, acc) do
-    do_filter(rest, [acc | <<grapheme::utf8>>])
+    do_filter(rest, <<acc::bits, grapheme::utf8>>)
   end
 
-  defp do_filter(<<_::binary-size(1), rest::binary>>, acc), do: do_filter(rest, [acc | "�"])
-
-  defp do_filter(<<>>, acc), do: IO.iodata_to_binary(acc)
+  defp do_filter(<<_, rest::binary>>, acc), do: do_filter(rest, <<acc::bits, "�">>)
+  defp do_filter(<<>>, acc), do: acc
 end
-
-IO.inspect(byte_size(twohundred_kilobyte_example), label: "Exact size of input")
 
 Benchee.run(
   %{
-    "Naive 3-liner, 207KB Input" => fn -> UniRecover.Benchmark.Naive.sub(twohundred_kilobyte_example) end,
-    "Simple Rebuild, 207KB Input" => fn -> UniRecover.Benchmark.Simple.sub(twohundred_kilobyte_example) end,
-    "UniRecover, 207KB Input" => fn -> UniRecover.sub(twohundred_kilobyte_example) end,
+    "Binary" => &UniRecover.Benchmark.Simple.sub/1,
+    "UniRecover" => &UniRecover.sub/1
+  },
+  inputs: %{
+    "207KB JSON Once Invalid" => File.read!("benchmarking/hll_server_list-single_error.json"),
+    "200KB Very Often Invalid" => String.duplicate(<<"abc", 233>>, 50_000),
+    "200KB Valid ASCII" => String.duplicate("abcd", 50_000),
+    "210KB Valid Unicode" => String.duplicate("こんにちは世界", 10_000)
   },
   time: 10,
   memory_time: 2,


### PR DESCRIPTION
This pull request benchmarks more scenarios and uses a better "naive" implementation.

The new implementation uses binaries and Erlang/OTP's ability to avoid allocating new binaries. It performs within the same order of magnitude as UniRecover in all benchmarks except one.

The new scenarios consider when the string is valid ASCII, valid Unicode (japanese characters) and also frequently invalid. You will notice UniRecover performs poorly when frequently invalid, using 56672 more memory than the new naive solution.

---

```
$ mix run benchmarking/benchmark.exs
Operating System: macOS
CPU Information: Apple M1 Max
Number of Available Cores: 10
Available memory: 32 GB
Elixir 1.16.0-dev
Erlang 26.0.2

Benchmark suite executing with the following configuration:
warmup: 2 s
time: 10 s
memory time: 2 s
reduction time: 0 ns
parallel: 1
inputs: 200KB Valid ASCII, 200KB Very Often Invalid, 207KB JSON Once Invalid, 210KB Valid Unicode
Estimated total run time: 1.87 min

Benchmarking Binary with input 200KB Valid ASCII ...
Benchmarking Binary with input 200KB Very Often Invalid ...
Benchmarking Binary with input 207KB JSON Once Invalid ...
Benchmarking Binary with input 210KB Valid Unicode ...
Benchmarking UniRecover with input 200KB Valid ASCII ...
Benchmarking UniRecover with input 200KB Very Often Invalid ...
Benchmarking UniRecover with input 207KB JSON Once Invalid ...
Benchmarking UniRecover with input 210KB Valid Unicode ...

##### With input 200KB Valid ASCII #####
Name                 ips        average  deviation         median         99th %
UniRecover       1937.10      516.24 μs    ±10.36%      512.08 μs      548.66 μs
Binary            833.40     1199.90 μs     ±8.35%     1145.63 μs     1502.78 μs

Comparison:
UniRecover       1937.10
Binary            833.40 - 2.32x slower +683.67 μs

Memory usage statistics:

Name          Memory usage
UniRecover            40 B
Binary               128 B - 3.20x memory usage +88 B

**All measurements for memory usage were the same**

##### With input 200KB Very Often Invalid #####
Name                 ips        average  deviation         median         99th %
Binary            806.73        1.24 ms     ±1.51%        1.23 ms        1.31 ms
UniRecover        157.10        6.37 ms    ±22.85%        6.15 ms       10.42 ms

Comparison:
Binary            806.73
UniRecover        157.10 - 5.14x slower +5.13 ms

Memory usage statistics:

Name          Memory usage
Binary               128 B
UniRecover       7254120 B - 56672.81x memory usage +7253992 B

**All measurements for memory usage were the same**

##### With input 207KB JSON Once Invalid #####
Name                 ips        average  deviation         median         99th %
UniRecover       1838.19      544.01 μs     ±1.60%      541.71 μs      579.69 μs
Binary            849.26     1177.50 μs     ±1.23%     1173.88 μs     1238.14 μs

Comparison:
UniRecover       1838.19
Binary            849.26 - 2.16x slower +633.49 μs

Memory usage statistics:

Name          Memory usage
UniRecover           296 B
Binary               128 B - 0.43x memory usage -168 B

**All measurements for memory usage were the same**

##### With input 210KB Valid Unicode #####
Name                 ips        average  deviation         median         99th %
UniRecover        1.14 K      879.31 μs     ±1.87%      875.79 μs      924.80 μs
Binary            1.09 K      920.40 μs     ±1.39%      917.08 μs      972.20 μs

Comparison:
UniRecover        1.14 K
Binary            1.09 K - 1.05x slower +41.09 μs

Memory usage statistics:

Name          Memory usage
UniRecover            40 B
Binary               128 B - 3.20x memory usage +88 B

**All measurements for memory usage were the same**
```